### PR TITLE
feat: handle FIFO messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-slack-notification",
-  "version": "1.5.1",
+  "version": "1.5.1-test",
   "private": true,
   "description": "Helix Slack Notification Service",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -75,10 +75,12 @@ async function run(request, context) {
     // typically, this happens when the function isn't triggered by SQS but invoked "manually"
     return new Response('', { status: 204 });
   }
-
   await Promise.all(records.map(async ({ body }) => {
     try {
-      const payload = JSON.parse(body);
+      let payload = JSON.parse(body);
+      if (payload.Message) {
+        payload = JSON.parse(payload.Message);
+      }
       await handleNotification(payload, context.env, log);
     } catch (e) {
       log.warn(`Unable to handle notification: [${body}]`, e);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,10 +141,12 @@ describe('Index Tests', () => {
     const result = await main(new Request('https://localhost/'), {
       records: [{
         body: JSON.stringify({
-          owner: 'owner',
-          repo: 'repo',
-          ref: 'ref',
-          op: 'index-published',
+          Message: JSON.stringify({
+            owner: 'owner',
+            repo: 'repo',
+            ref: 'ref',
+            op: 'index-published',
+          }),
         }),
       }],
       env,


### PR DESCRIPTION
Allows handler to work as both standard queue and FIFO queue trigger.